### PR TITLE
feat: add Unix socket connection support using unix:// URL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ const version = await client.getAPIVersion();
 console.log(version);
 ```
 
+### Unix Socket Connection
+
+If your supervisord is configured to use a Unix socket instead of TCP, you can use the `unix://` URL format (consistent with supervisorctl's `serverurl` configuration):
+
+```ts
+import { SupervisordClient } from "node-supervisord";
+
+// Connect via Unix socket
+const client = new SupervisordClient("unix:///tmp/supervisor.sock");
+
+// With authentication
+const client = new SupervisordClient("unix:///tmp/supervisor.sock", {
+  username: "your-username",
+  password: "your-password",
+});
+```
+
+**Note:** Unix socket support is available on Linux and macOS only. Windows users should use TCP connections.
+
 To see the available methods, you can visit [http://supervisord.org/api.html](http://supervisord.org/api.html)
 
 ## Contributing

--- a/src/supervisord-client.ts
+++ b/src/supervisord-client.ts
@@ -2,6 +2,9 @@ import { UrlWithStringQuery, parse } from "url";
 import { Client, createClient } from "xmlrpc";
 import { $SupervisorMethod, SupervisordClientMethod } from "./methods";
 
+type ClientOptions = Parameters<typeof createClient>[0];
+type ExtendedClientOptions = ClientOptions & { socketPath?: string };
+
 export interface SupervisordClientOptions {
   username: string;
   password: string;
@@ -10,36 +13,41 @@ export interface SupervisordClientOptions {
 export class SupervisordClient extends SupervisordClientMethod {
   private client: Client;
 
-  constructor(host: string, options?: SupervisordClientOptions) {
+  constructor(host: string, options?: SupervisordClientOptions);
+  constructor(host: UrlWithStringQuery, options?: SupervisordClientOptions);
+  constructor(host: string | UrlWithStringQuery, options?: SupervisordClientOptions) {
     super();
 
-    let hostParts: UrlWithStringQuery;
-    let basicAuth: { user: string; pass: string };
+    const clientOptions: ExtendedClientOptions = {
+      path: "/RPC2",
+    };
 
-    if (typeof host == "string") {
-      if (host.indexOf("http") !== 0) {
+    let hostParts: UrlWithStringQuery;
+
+    if (typeof host === "string") {
+      if (!host.startsWith("http://") && !host.startsWith("unix://")) {
         host = "http://" + host;
       }
       hostParts = parse(host, false);
-      if (options) {
-        basicAuth = {
-          user: options.username,
-          pass: options.password,
-        };
-      }
     } else if (host) {
       hostParts = host;
     }
 
-    if (!hostParts.hostname) hostParts.hostname = "localhost";
-    if (!hostParts.port) hostParts.port = "9001";
+    if (options) {
+      clientOptions.basic_auth = {
+        user: options.username,
+        pass: options.password,
+      };
+    }
 
-    this.client = createClient({
-      host: hostParts.hostname,
-      port: parseInt(hostParts.port),
-      path: "/RPC2",
-      basic_auth: basicAuth,
-    });
+    if (hostParts.protocol === "unix:") {
+      clientOptions.socketPath = hostParts.pathname;
+    } else {
+      clientOptions.host = hostParts.hostname || "localhost";
+      clientOptions.port = parseInt(hostParts.port || "9001");
+    }
+
+    this.client = createClient(clientOptions as ExtendedClientOptions);
   }
 
   _call(method: string, params: any[], callback: (err: any, result: object) => void) {


### PR DESCRIPTION
## Summary

- Add Unix socket connection support using the `unix://` URL format
- Unify URL parsing logic by converting to URL objects first, then processing, to avoid code redundancy
- Update README documentation to explain Unix socket usage

## Usage

```TypeScript
// Connect via Unix socket
const client = new SupervisordClient("unix:///tmp/supervisor.sock");

// With authentication
const client = new SupervisordClient("unix:///tmp/supervisor.sock", {
  username: "user",
  password: "password",
});
```

## Notes

- Unix socket support is available on Linux and macOS only
- URL format is consistent with supervisorctl's `serverurl` configuration